### PR TITLE
Remove unused return value from action

### DIFF
--- a/test/integration/state_data_members.cpp
+++ b/test/integration/state_data_members.cpp
@@ -39,7 +39,6 @@ const auto readDataAction = [](auto&& event, auto& source, auto& target) {
 const auto writeDataAction = [](auto&& event, auto& source, auto& target) {
     source.data = event.sourceData;
     target.data = event.targetData;
-    return true;
 };
 
 // Guard


### PR DESCRIPTION
Maybe a copy-paste error from the guard below?

I would prefer if we could change the syntax so that the action can return the target state instead of getting it as parameter.
this would allow to use non-default-constructible states.