### PR TITLE
fix: Internal transition does not compile with on_entry

### DIFF
--- a/src/include/hsm/details/collect_initial_states.h
+++ b/src/include/hsm/details/collect_initial_states.h
@@ -5,9 +5,10 @@
 #include "hsm/details/idx.h"
 
 #include <boost/hana/find.hpp>
+#include <boost/hana/maximum.hpp>
 #include <boost/hana/size.hpp>
 #include <boost/hana/transform.hpp>
-#include <boost/hana/maximum.hpp>
+#include <boost/hana/zip.hpp>
 
 #include <iostream>
 #include <vector>

--- a/src/include/hsm/details/flatten_internal_transition_table.h
+++ b/src/include/hsm/details/flatten_internal_transition_table.h
@@ -52,7 +52,7 @@ template <class Transition, class States>
 constexpr auto extend_internal_transition(Transition internalTransition, States states)
 {
     return bh::transform(states, [internalTransition](auto state) {
-        return details::extended_transition(
+        return details::internal_extended_transition(
             internalTransition.parent(),
             details::transition(
                 state,

--- a/src/include/hsm/details/has_action.h
+++ b/src/include/hsm/details/has_action.h
@@ -14,14 +14,15 @@ namespace bh {
 using namespace boost::hana;
 }
 
-constexpr auto has_substate_initial_state_entry_action = [](auto&& target) {
-    return bh::if_(
-        has_transition_table(target),
-        [](auto&& target) { return has_entry_action(bh::at_c<0>(collect_initial_states(target))); },
-        [](auto&&) { return bh::false_c; })(target);
+constexpr auto has_substate_initial_state_entry_action = [](auto target) {
+    if constexpr (has_transition_table(target)) {
+        return has_entry_action(bh::at_c<0>(collect_initial_states(target)));
+    } else {
+        return bh::false_c;
+    }
 };
 
-constexpr auto has_action = [](auto&& transition) {
+constexpr auto has_action = [](auto transition) {
     return bh::or_(
         bh::not_(is_no_action(transition.action())),
         has_entry_action(transition.target()),

--- a/src/include/hsm/details/resolve_state.h
+++ b/src/include/hsm/details/resolve_state.h
@@ -119,7 +119,9 @@ template <class Transition> constexpr auto resolveExitAction(Transition transiti
 
 template <class Transition> constexpr auto resolveNoAction(Transition transition)
 {
-    if constexpr (is_no_action(transition.action())) {
+    const auto isNoAction = is_no_action(transition.action());
+
+    if constexpr (isNoAction) {
         return [](auto&&...) {};
     } else {
         return transition.action();

--- a/src/include/hsm/details/resolve_state.h
+++ b/src/include/hsm/details/resolve_state.h
@@ -141,7 +141,9 @@ template <class Transition> constexpr auto resolveEntryExitAction(Transition tra
 
 template <class Transition> constexpr auto resolveAction(Transition transition)
 {
-    if constexpr (has_action(transition)) {
+    const auto hasAction = has_action(transition);
+
+    if constexpr (hasAction) {
         return resolveEntryExitAction(transition);
     } else {
         return transition.action();

--- a/src/include/hsm/details/transition.h
+++ b/src/include/hsm/details/transition.h
@@ -68,7 +68,14 @@ template <class Event, class Guard, class Action> struct InternalTransition {
     const Action m_action;
 };
 
-template <class Parent, class Source, class Event, class Guard, class Action, class Target>
+template <
+    class Parent,
+    class Source,
+    class Event,
+    class Guard,
+    class Action,
+    class Target,
+    bool Internal>
 struct ExtendedTransition {
     constexpr ExtendedTransition(
         Parent, Source, Event, Guard guard, Action action, Target)
@@ -107,6 +114,11 @@ struct ExtendedTransition {
         return Target {};
     }
 
+    [[nodiscard]] constexpr auto internal() const -> bool
+    {
+        return Internal;
+    }
+
   private:
     const Guard m_guard;
     const Action m_action;
@@ -118,19 +130,36 @@ constexpr auto transition
 constexpr auto internal_transition
     = [](auto&&... xs) { return InternalTransition<std::decay_t<decltype(xs)>...> { xs... }; };
 
-constexpr auto extended_transition = [](auto&& parent, auto&& transition) {
+constexpr auto extended_transition = [](auto parent, auto transition) {
     return ExtendedTransition<
         std::decay_t<decltype(parent)>,
         std::decay_t<decltype(transition.source())>,
         std::decay_t<decltype(transition.event())>,
         std::decay_t<decltype(transition.guard())>,
         std::decay_t<decltype(transition.action())>,
-        std::decay_t<decltype(transition.target())>> { parent,
-                                                       transition.source(),
-                                                       transition.event(),
-                                                       transition.guard(),
-                                                       transition.action(),
-                                                       transition.target() };
+        std::decay_t<decltype(transition.target())>,
+        false> { parent,
+                 transition.source(),
+                 transition.event(),
+                 transition.guard(),
+                 transition.action(),
+                 transition.target() };
+};
+
+constexpr auto internal_extended_transition = [](auto parent, auto transition) {
+    return ExtendedTransition<
+        std::decay_t<decltype(parent)>,
+        std::decay_t<decltype(transition.source())>,
+        std::decay_t<decltype(transition.event())>,
+        std::decay_t<decltype(transition.guard())>,
+        std::decay_t<decltype(transition.action())>,
+        std::decay_t<decltype(transition.target())>,
+        true> { parent,
+                transition.source(),
+                transition.event(),
+                transition.guard(),
+                transition.action(),
+                transition.target() };
 };
 }
 }

--- a/src/include/hsm/gen/hsm.h
+++ b/src/include/hsm/gen/hsm.h
@@ -1052,7 +1052,9 @@ template <class Transition> constexpr auto resolveExitAction(Transition transiti
 
 template <class Transition> constexpr auto resolveNoAction(Transition transition)
 {
-    if constexpr (is_no_action(transition.action())) {
+    const auto isNoAction = is_no_action(transition.action());
+
+    if constexpr (isNoAction) {
         return [](auto&&...) {};
     } else {
         return transition.action();

--- a/src/include/hsm/gen/hsm.h
+++ b/src/include/hsm/gen/hsm.h
@@ -789,6 +789,7 @@ constexpr auto getGuardIdx = [](auto rootState, auto guard) {
 #include <boost/hana/maximum.hpp>
 #include <boost/hana/size.hpp>
 #include <boost/hana/transform.hpp>
+#include <boost/hana/zip.hpp>
 
 #include <iostream>
 #include <vector>
@@ -918,10 +919,9 @@ using namespace boost::hana;
 }
 
 constexpr auto has_substate_initial_state_entry_action = [](auto target) {
-    if constexpr(has_transition_table(target)){
+    if constexpr (has_transition_table(target)) {
         return has_entry_action(bh::at_c<0>(collect_initial_states(target)));
-    }
-    else {
+    } else {
         return bh::false_c;
     }
 };
@@ -1074,7 +1074,9 @@ template <class Transition> constexpr auto resolveEntryExitAction(Transition tra
 
 template <class Transition> constexpr auto resolveAction(Transition transition)
 {
-    if constexpr (has_action(transition)) {
+    const auto hasAction = has_action(transition);
+
+    if constexpr (hasAction) {
         return resolveEntryExitAction(transition);
     } else {
         return transition.action();

--- a/test/integration/internal_transition.cpp
+++ b/test/integration/internal_transition.cpp
@@ -14,10 +14,20 @@ namespace {
 struct S1 {
 };
 struct S2 {
+    static constexpr auto on_entry()
+    {
+        return [](auto event, auto...) { (void)event.name; };
+    }
+
+    static constexpr auto on_exit()
+    {
+        return [](auto event, auto...) { (void)event.name; };
+    }
 };
 
 // Events
 struct e1 {
+    std::string name = "e1";
 };
 struct e2 {
     e2(const std::shared_ptr<std::promise<void>>& called)
@@ -25,6 +35,7 @@ struct e2 {
     {
     }
     std::shared_ptr<std::promise<void>> called;
+    std::string name = "e2";
 };
 struct e3 {
 };
@@ -36,6 +47,9 @@ struct e4 {
     std::shared_ptr<std::promise<void>> called;
 };
 struct e5 {
+};
+struct e6 {
+    std::string name = "e2";
 };
 
 // Guards
@@ -72,9 +86,10 @@ struct MainState {
     {
         // clang-format off
         return hsm::transition_table(
-            * hsm::state<S1> + hsm::event<e1> = hsm::state<S2>,
-              hsm::state<S1> + hsm::event<e2> = hsm::state<S2>,
-              hsm::state<S1> + hsm::event<e3> = hsm::state<SubState>
+            * hsm::state<S1> + hsm::event<e1> = hsm::state<S2>
+            , hsm::state<S1> + hsm::event<e2> = hsm::state<S2>
+            , hsm::state<S1> + hsm::event<e3> = hsm::state<SubState>
+            , hsm::state<S2> + hsm::event<e6> = hsm::state<S1>
         );
         // clang-format on
     }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
           for_each_tests.cpp
           transition_table_traits_tests.cpp
           chain_actions_tests.cpp
+          has_action_tests.cpp
         )
 
 set_property(TARGET hsmUnitTests PROPERTY

--- a/test/unit/has_action_tests.cpp
+++ b/test/unit/has_action_tests.cpp
@@ -1,0 +1,36 @@
+#include "hsm/details/dispatch_table.h"
+#include "hsm/details/has_action.h"
+#include "hsm/details/pseudo_states.h"
+#include "hsm/details/state.h"
+#include "hsm/details/transition.h"
+
+#include <boost/hana/basic_tuple.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace boost::hana;
+using namespace ::testing;
+
+namespace hsm::test {
+
+class HasActionTests : public Test {
+};
+
+struct T {
+};
+struct P {
+};
+struct S {
+};
+
+TEST_F(HasActionTests, should_recognize_action)
+{
+    auto action = []() {};
+    constexpr auto transition
+        = details::transition(state_t<T> {}, "event", "guard", action, state_t<P> {});
+    constexpr auto extendedTransition
+        = details::extended_transition(hsm::state_t<S> {}, transition);
+
+    static_assert(has_action(extendedTransition));
+}
+}

--- a/test/unit/traits_tests.cpp
+++ b/test/unit/traits_tests.cpp
@@ -143,9 +143,9 @@ TEST_F(TraitsTests, should_recognize_no_action)
 {
     namespace bh = boost::hana;
 
-    auto result = bh::if_(
+    constexpr auto result = bh::if_(
         hsm::is_no_action(hsm::noAction {}), []() { return true; }, []() { return false; })();
-    ASSERT_TRUE(result);
+    static_assert(result);
 }
 
 TEST_F(TraitsTests, should_recognize_substate_initial_state_entry_action)


### PR DESCRIPTION
**Problem:**
Internal transition integration test does not compile anymore when some state has an `on_entry` function and accesses member functions. The issue occurs because internal transitions are like normal transitions but do not change the state. But they have still an entry action.