### PR TITLE
feat: non default constructable state targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ A click on a particular feature check mark will forward to the feature documenta
     <td><center>✗</center></td>
     <td><center>✗</center></td>
   </tr>
+  <tr>
+    <td>Custom target state construction</td>
+    <td><center><a href="test/integration/custom_targets.cpp">✓</a></center></td>
+    <td><center>✗</center></td>
+    <td><center>✗</center></td>
+    <td><center>✗</center></td>
+  </tr>
 </table> 
 
 ## Example ([Run](https://godbolt.org/z/szEPEG))

--- a/src/include/hsm/details/collect_initial_states.h
+++ b/src/include/hsm/details/collect_initial_states.h
@@ -23,8 +23,7 @@ namespace hsm {
 constexpr auto collect_initial_states = [](auto parentState) {
     constexpr auto childStates = collect_child_states(parentState);
     constexpr auto initialStates = bh::filter(childStates, is_initial_state);
-    return bh::transform(
-        initialStates, [](auto initialState) { return unwrap_typeid(initialState).get_state(); });
+    return bh::transform(initialStates, [](auto initialState) { return get_state(initialState); });
 };
 
 /**

--- a/src/include/hsm/details/collect_states.h
+++ b/src/include/hsm/details/collect_states.h
@@ -23,14 +23,14 @@ namespace {
 constexpr auto resolveInitialState = [](auto transition) {
     return bh::if_(
         is_initial_state(transition.source()),
-        [](auto initial) { return unwrap_typeid(initial).get_state(); },
+        [](auto initial) { return get_state(initial); },
         [](auto source) { return source; })(transition.source());
 };
 
 constexpr auto resolveExtentedInitialState = [](auto transition) {
     return bh::if_(
         is_initial_state(transition.source()),
-        [](auto initial) { return unwrap_typeid(initial).get_state(); },
+        [](auto initial) { return get_state(initial); },
         [](auto source) { return source; })(transition.source());
 };
 
@@ -76,7 +76,7 @@ constexpr auto collect_states_recursive = [](auto&& parentState) {
 };
 
 const auto collect_child_state_typeids = [](auto&& state) {
-    auto transitions = unwrap_typeid(state).make_transition_table();
+    auto transitions = make_transition_table2(state);
     auto collectedStates = bh::flatten(bh::transform(transitions, extractStateTypeids));
 
     return remove_duplicate_typeids(collectedStates);

--- a/src/include/hsm/details/create_state.h
+++ b/src/include/hsm/details/create_state.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace hsm {
+
+template <class StateFactory> class CreateState {
+  public:
+    constexpr CreateState(StateFactory stateFactory)
+        : m_stateFactory(stateFactory)
+    {
+    }
+
+    template <class Event, class Source, class Target>
+    constexpr auto operator()(Event event, Source source, Target target) const
+    {
+        *target = m_stateFactory(event, source);
+    }
+
+  private:
+    StateFactory m_stateFactory;
+};
+
+template <class StateFactory> constexpr auto create_state(StateFactory stateFactory)
+{
+    return CreateState<StateFactory> { stateFactory };
+}
+}

--- a/src/include/hsm/details/flatten_internal_transition_table.h
+++ b/src/include/hsm/details/flatten_internal_transition_table.h
@@ -27,8 +27,7 @@ constexpr auto get_internal_transition_table = [](auto state) {
     return bh::if_(
         has_internal_transition_table(state),
         [](auto parentState) {
-            auto internalTransitionTable
-                = unwrap_typeid(parentState).make_internal_transition_table();
+            auto internalTransitionTable = make_internal_transition_table(parentState);
             return bh::transform(internalTransitionTable, [parentState](auto internalTransition) {
                 return details::extended_transition(
                     parentState,

--- a/src/include/hsm/details/idx.h
+++ b/src/include/hsm/details/idx.h
@@ -98,11 +98,4 @@ const auto has_history = [](auto rootState) {
     auto historyTransitions = bh::filter(transitions, is_history_transition);
     return bh::size(historyTransitions);
 };
-
-const auto get_unexpected_event_handler = [](auto rootState) {
-    return bh::if_(
-        has_unexpected_event_handler(rootState),
-        [](auto rootState) { return unwrap_typeid(rootState).on_unexpected_event(); },
-        [](auto) { return [](auto /*event*/) {}; })(rootState);
-};
 }

--- a/src/include/hsm/details/resolve_state.h
+++ b/src/include/hsm/details/resolve_state.h
@@ -14,13 +14,13 @@ constexpr auto resolveDst = [](auto&& transition) {
     return bh::apply([](auto&& dstTypeid){
         return lazy_switch_(
             // TODO: make multi region capable    
-            case_(bh::make_lazy(has_transition_table(dstTypeid)), [](auto&& submachine, auto&&) { return bh::at_c<0>(collect_initial_states(submachine));}),
-            case_(bh::make_lazy(is_entry_state(dstTypeid)),       [](auto&& entry, auto&&) { return unwrap_typeid(entry).get_state(); }),
-            case_(bh::make_lazy(is_direct_state(dstTypeid)),      [](auto&& direct, auto&&) { return unwrap_typeid(direct).get_state(); }),
+            case_(bh::make_lazy(has_transition_table(dstTypeid)), [](auto&& submachine) { return bh::at_c<0>(collect_initial_states(submachine));}),
+            case_(bh::make_lazy(is_entry_state(dstTypeid)),       [](auto&& entry) { return get_state(entry); }),
+            case_(bh::make_lazy(is_direct_state(dstTypeid)),      [](auto&& direct) { return get_state(direct); }),
             // TODO: make multi region capable 
-            case_(bh::make_lazy(is_history_state(dstTypeid)),     [](auto&&, auto&& history) { return bh::at_c<0>(collect_initial_states(history.get_parent_state()));}),
-            case_(bh::make_lazy((otherwise())),                   [](auto&& dstTypeid, auto&&) { return dstTypeid; }))
-            (dstTypeid, unwrap_typeid(dstTypeid));
+            case_(bh::make_lazy(is_history_state(dstTypeid)),     [](auto&& history) { return bh::at_c<0>(collect_initial_states(get_parent_state(history)));}),
+            case_(bh::make_lazy((otherwise())),                   [](auto&& dstTypeid) { return dstTypeid; }))
+            (dstTypeid);
     },
     transition.target());
     // clang-format on
@@ -31,9 +31,9 @@ constexpr auto resolveDstParent = [](auto transition) {
     return bh::apply([](auto&& dstTypeid, auto&& transition){
         return lazy_switch_(
             case_(bh::make_lazy(has_transition_table(dstTypeid)), [](auto&& submachine, auto&&) { return submachine; }),
-            case_(bh::make_lazy(is_entry_state(dstTypeid)),       [](auto&& entry, auto&&) { return unwrap_typeid(entry).get_parent_state(); }),
-            case_(bh::make_lazy(is_direct_state(dstTypeid)),      [](auto&& direct, auto&&) { return unwrap_typeid(direct).get_parent_state(); }),
-            case_(bh::make_lazy(is_history_state(dstTypeid)),     [](auto&& history, auto&&) { return unwrap_typeid(history).get_parent_state(); }),
+            case_(bh::make_lazy(is_entry_state(dstTypeid)),       [](auto&& entry, auto&&) { return get_parent_state(entry); }),
+            case_(bh::make_lazy(is_direct_state(dstTypeid)),      [](auto&& direct, auto&&) { return get_parent_state(direct); }),
+            case_(bh::make_lazy(is_history_state(dstTypeid)),     [](auto&& history, auto&&) { return get_parent_state(history); }),
             case_(bh::make_lazy(otherwise()),                     [](auto&&, auto&& transition) { return transition.parent(); }))
             (dstTypeid, transition);
     },
@@ -45,9 +45,9 @@ constexpr auto resolveSrc = [](auto&& transition) {
     // clang-format off
     return bh::apply([](auto&& src){
         return lazy_switch_(
-            case_(bh::make_lazy(is_initial_state(src)), [](auto&& initial) { return unwrap_typeid(initial).get_state(); }),    
-            case_(bh::make_lazy(is_exit_state(src)),    [](auto&& exit) { return unwrap_typeid(exit).get_state(); }),
-            case_(bh::make_lazy(is_direct_state(src)),  [](auto&& direct) { return unwrap_typeid(direct).get_state(); }),
+            case_(bh::make_lazy(is_initial_state(src)), [](auto&& initial) { return get_state(initial); }),    
+            case_(bh::make_lazy(is_exit_state(src)),    [](auto&& exit) { return get_state(exit); }),
+            case_(bh::make_lazy(is_direct_state(src)),  [](auto&& direct) { return get_state(direct); }),
             case_(bh::make_lazy(otherwise()),           [](auto&& state) { return state; }))
             (src);    
     },
@@ -59,8 +59,8 @@ constexpr auto resolveSrcParent = [](auto&& transition) {
     // clang-format off
     return bh::apply([](auto&& src, auto&& transition){
         return lazy_switch_(
-            case_(bh::make_lazy(is_exit_state(src)),   [](auto&& exit, auto&&) { return unwrap_typeid(exit).get_parent_state(); }),
-            case_(bh::make_lazy(is_direct_state(src)), [](auto&& direct, auto&&) { return unwrap_typeid(direct).get_parent_state(); }),
+            case_(bh::make_lazy(is_exit_state(src)),   [](auto&& exit, auto&&) { return get_parent_state(exit); }),
+            case_(bh::make_lazy(is_direct_state(src)), [](auto&& direct, auto&&) { return get_parent_state(direct); }),
             case_(bh::make_lazy(otherwise()),          [](auto&&, auto&& transition) { return transition.parent(); }))
             (src, transition);
     },

--- a/src/include/hsm/details/reuse_state.h
+++ b/src/include/hsm/details/reuse_state.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace hsm {
+
+template <class Action> class ReuseState {
+  public:
+    constexpr ReuseState(Action action)
+        : m_action(action)
+    {
+    }
+
+    template <class Event, class Source, class Target>
+    constexpr auto operator()(Event event, Source source, Target target) const
+    {
+        m_action(event, source, **target);
+    }
+
+  private:
+    Action m_action;
+};
+
+template <class Action> constexpr auto reuse_state(Action action)
+{
+    return ReuseState<Action> { action };
+}
+}

--- a/src/include/hsm/hsm.h
+++ b/src/include/hsm/hsm.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "hsm/details/create_state.h"
+#include "hsm/details/reuse_state.h"
 #include "hsm/details/sm.h"
 #include "hsm/details/state.h"
 #include "hsm/details/transition_table.h"

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(hsmIntegrationTests
         state_data_members.cpp
         transition_logging.cpp
         amalgamation_header.cpp
+        custom_targets.cpp
 )
 
 target_link_libraries(hsmIntegrationTests

--- a/test/integration/basic_transitions.cpp
+++ b/test/integration/basic_transitions.cpp
@@ -88,7 +88,7 @@ struct MainState {
         // clang-format on
     }
 
-    constexpr auto on_unexpected_event()
+    static constexpr auto on_unexpected_event()
     {
         return [](auto event) {
             throw std::runtime_error(

--- a/test/integration/custom_targets.cpp
+++ b/test/integration/custom_targets.cpp
@@ -1,0 +1,119 @@
+#include "hsm/hsm.h"
+
+#include <boost/hana.hpp>
+#include <boost/hana/experimental/printable.hpp>
+#include <gtest/gtest.h>
+
+#include <future>
+#include <memory>
+
+namespace {
+
+using namespace ::testing;
+using namespace boost::hana;
+
+// States
+struct S1 {
+    std::string name = "S1";
+};
+struct S2 {
+    S2(std::string name)
+        : name(name)
+    {
+    }
+    const std::string name;
+};
+
+// Events
+struct e1 {
+    std::string name = "e1";
+};
+struct e2 {
+};
+struct e3 {
+};
+struct e4 {
+    std::string name = "e4";
+};
+
+/*
+ * A state factory is functor that constructs a non default constructible target state
+ *
+ * @param[in] event event of the transition
+ * @param[in] source source state of the transition
+ *
+ * @return unique_ptr of the target state
+ */
+const auto stateFactory
+    = [](auto event, auto source) { return std::make_unique<S2>(event.name + source.name); };
+
+const auto alternativeStateFactory = [](auto event, auto source) {
+    return std::make_unique<S2>(std::string { "static name" } + event.name + source.name);
+};
+
+const auto log = [](auto event, auto source, auto target) {
+    std::cout << experimental::print(typeid_(source)) << ".name=" << source.name << " + "
+              << experimental::print(typeid_(event)) << " = "
+              << experimental::print(typeid_(target)) << ".name=" << target.name << std::endl;
+};
+
+struct MainState {
+    static constexpr auto make_transition_table()
+    {
+        // clang-format off
+        return hsm::transition_table(
+            // Transitions with a non default constructible target need to create the state with
+            // the create_state action and provide a state factory functor
+            * hsm::state<S1> + hsm::event<e1> / hsm::create_state(stateFactory)            = hsm::state<S2>
+            , hsm::state<S1> + hsm::event<e4> / hsm::create_state(alternativeStateFactory) = hsm::state<S2> 
+            // If no create_state action is used the target state should already be created
+            , hsm::state<S1> + hsm::event<e3>                                              = hsm::state<S2>
+            // If you want add an action to the transition you need to encapsulate the action
+            // into the reuse_state action
+            , hsm::state<S1> + hsm::event<e2> / hsm::reuse_state(log)                      = hsm::state<S2>
+            , hsm::state<S2> + hsm::event<e2> / log                                        = hsm::state<S1>
+        );
+        // clang-format on
+    }
+
+    static constexpr auto on_unexpected_event()
+    {
+        return [](auto event) {
+            throw std::runtime_error(
+                std::string("unexpected event ") + experimental::print(typeid_(event)));
+        };
+    }
+};
+}
+
+class CustomTargetsTests : public Test {
+  protected:
+    hsm::sm<MainState> sm;
+};
+
+TEST_F(CustomTargetsTests, should_construct_state_on_transition)
+{
+    ASSERT_TRUE(sm.is(hsm::state<S1>));
+    sm.process_event(e1 {});
+    ASSERT_TRUE(sm.is(hsm::state<S2>));
+}
+
+TEST_F(CustomTargetsTests, should_construct_state_on_transition_with_alternative_state_factory)
+{
+    ASSERT_TRUE(sm.is(hsm::state<S1>));
+    sm.process_event(e4 {});
+    ASSERT_TRUE(sm.is(hsm::state<S2>));
+}
+
+TEST_F(CustomTargetsTests, should_reuse_constructed_state)
+{
+    ASSERT_TRUE(sm.is(hsm::state<S1>));
+    sm.process_event(e1 {});
+    sm.process_event(e2 {});
+    sm.process_event(e2 {});
+    ASSERT_TRUE(sm.is(hsm::state<S2>));
+    sm.process_event(e2 {});
+    ASSERT_TRUE(sm.is(hsm::state<S1>));
+    sm.process_event(e3 {});
+    ASSERT_TRUE(sm.is(hsm::state<S2>));
+}

--- a/test/integration/defer_events.cpp
+++ b/test/integration/defer_events.cpp
@@ -23,7 +23,7 @@ struct e3 {
 
 // States
 struct S1 {
-    constexpr auto defer_events()
+    static constexpr auto defer_events()
     {
         return hsm::events<e2, e3>;
     }

--- a/test/integration/entry_exit_actions.cpp
+++ b/test/integration/entry_exit_actions.cpp
@@ -12,11 +12,11 @@ using namespace ::testing;
 struct S1 {
 };
 struct S2 {
-    constexpr auto on_entry()
+    static constexpr auto on_entry()
     {
         return [](auto event, auto /*source*/, auto /*target*/) { event.called->set_value(); };
     }
-    constexpr auto on_exit()
+    static constexpr auto on_exit()
     {
         return [](auto event, auto /*source*/, auto /*target*/) { event.called->set_value(); };
     }
@@ -55,12 +55,12 @@ struct SubState {
         // clang-format on
     }
 
-    constexpr auto on_entry()
+    static constexpr auto on_entry()
     {
         return [](auto event, auto /*source*/, auto /*target*/) { event.called->set_value(); };
     }
 
-    constexpr auto on_exit()
+    static constexpr auto on_exit()
     {
         return [](auto event, auto /*source*/, auto /*target*/) { event.called->set_value(); };
     }

--- a/test/integration/internal_transition.cpp
+++ b/test/integration/internal_transition.cpp
@@ -57,7 +57,7 @@ struct SubState {
         // clang-format on
     }
 
-    constexpr auto make_internal_transition_table()
+    static constexpr auto make_internal_transition_table()
     {
         // clang-format off
         return hsm::transition_table(
@@ -79,7 +79,7 @@ struct MainState {
         // clang-format on
     }
 
-    constexpr auto make_internal_transition_table()
+    static constexpr auto make_internal_transition_table()
     {
         // clang-format off
         return hsm::transition_table(

--- a/test/integration/state_data_members.cpp
+++ b/test/integration/state_data_members.cpp
@@ -19,7 +19,7 @@ struct S2 {
 };
 
 struct S3 {
-    constexpr auto on_entry()
+    static constexpr auto on_entry()
     {
         return [](auto event, auto& source, auto& target) {
             source.data = event.sourceData;
@@ -27,7 +27,7 @@ struct S3 {
         };
     }
 
-    constexpr auto on_exit()
+    static constexpr auto on_exit()
     {
         return [](auto& event, auto source, auto target) {
             event.sourceData = source.data;
@@ -97,7 +97,7 @@ struct SubState {
         // clang-format on
     }
 
-    constexpr auto on_entry()
+    static constexpr auto on_entry()
     {
         return [](auto event, auto& source, auto& target) {
             source.data = event.sourceData;

--- a/test/integration/unexpected_transition_handler.cpp
+++ b/test/integration/unexpected_transition_handler.cpp
@@ -40,7 +40,7 @@ struct MainState {
         // clang-format on
     }
 
-    constexpr auto on_unexpected_event()
+    static constexpr auto on_unexpected_event()
     {
         return [](auto event) { event.called->set_value(); };
     }

--- a/test/unit/collect_states_tests.cpp
+++ b/test/unit/collect_states_tests.cpp
@@ -47,7 +47,7 @@ const auto g1 = [](auto) { return true; };
 const auto a1 = [](auto /*event*/) {};
 
 struct Defer {
-    constexpr auto defer_events()
+    static constexpr auto defer_events()
     {
         return hsm::events<e1>;
     }    
@@ -55,11 +55,11 @@ struct Defer {
 
 struct S {
 
-    constexpr auto on_entry()
+    static constexpr auto on_entry()
     {
         return [](auto counter) { (*counter)++; };
     }
-    constexpr auto on_exit()
+    static constexpr auto on_exit()
     {
         return [](auto counter) { (*counter)++; };
     }
@@ -110,7 +110,7 @@ struct MainState {
 TEST_F(CollectStatesTests, should_collect_child_states_typeids)
 {
     struct S {
-        auto make_transition_table()
+        static constexpr auto make_transition_table()
         {
             return hsm::transition_table(
                 hsm::transition(hsm::state_t<S1> {}, 0, 0, 0, hsm::state_t<S1> {}),

--- a/test/unit/flatten_internal_transition_table_tests.cpp
+++ b/test/unit/flatten_internal_transition_table_tests.cpp
@@ -13,7 +13,7 @@ using namespace hsm;
 namespace {
 
 struct T {
-    constexpr auto make_internal_transition_table()
+    static constexpr auto make_internal_transition_table()
     {
         return hsm::transition_table(hsm::internal_transition("event", "guard", "action"));
     }
@@ -26,7 +26,7 @@ struct P {
             hsm::transition(hsm::state_t<T> {}, "event", "guard", "action", hsm::state_t<T> {}));
     }
 
-    constexpr auto make_internal_transition_table()
+    static constexpr auto make_internal_transition_table()
     {
         return hsm::transition_table(hsm::internal_transition("event", "guard", "action"));
     }
@@ -39,7 +39,7 @@ struct S {
             hsm::transition(hsm::state_t<T> {}, "event", "guard", "action", hsm::state_t<P> {}));
     }
 
-    constexpr auto make_internal_transition_table()
+    static constexpr auto make_internal_transition_table()
     {
         return hsm::transition_table(hsm::internal_transition("event", "guard", "action"));
     }

--- a/test/unit/make_states_map_tests.cpp
+++ b/test/unit/make_states_map_tests.cpp
@@ -77,23 +77,23 @@ TEST_F(MakeStatesMapTests, should_make_states_map)
     ASSERT_EQ(bh::size_c<6>, bh::size(statesMap));
 
     ASSERT_EQ(
-        bh::typeid_(std::shared_ptr<S1> {}),
-        bh::typeid_(bh::find(statesMap, bh::typeid_(hsm::state_t<S1> {})).value()));
+        bh::typeid_(std::unique_ptr<S1> {}),
+        bh::typeid_(*bh::find(statesMap, bh::typeid_(hsm::state_t<S1> {})).value()));
     ASSERT_EQ(
-        bh::typeid_(std::shared_ptr<S2> {}),
-        bh::typeid_(bh::find(statesMap, bh::typeid_(hsm::state_t<S2> {})).value()));
+        bh::typeid_(std::unique_ptr<S2> {}),
+        bh::typeid_(*bh::find(statesMap, bh::typeid_(hsm::state_t<S2> {})).value()));
     ASSERT_EQ(
-        bh::typeid_(std::shared_ptr<S3> {}),
-        bh::typeid_(bh::find(statesMap, bh::typeid_(hsm::state_t<S3> {})).value()));
+        bh::typeid_(std::unique_ptr<S3> {}),
+        bh::typeid_(*bh::find(statesMap, bh::typeid_(hsm::state_t<S3> {})).value()));
     ASSERT_EQ(
-        bh::typeid_(std::shared_ptr<S4> {}),
-        bh::typeid_(bh::find(statesMap, bh::typeid_(hsm::state_t<S4> {})).value()));
+        bh::typeid_(std::unique_ptr<S4> {}),
+        bh::typeid_(*bh::find(statesMap, bh::typeid_(hsm::state_t<S4> {})).value()));
     ASSERT_EQ(
-        bh::typeid_(std::shared_ptr<MainState> {}),
-        bh::typeid_(bh::find(statesMap, bh::typeid_(hsm::state_t<MainState> {})).value()));
+        bh::typeid_(std::unique_ptr<MainState> {}),
+        bh::typeid_(*bh::find(statesMap, bh::typeid_(hsm::state_t<MainState> {})).value()));
     ASSERT_EQ(
-        bh::typeid_(std::shared_ptr<SubState> {}),
-        bh::typeid_(bh::find(statesMap, bh::typeid_(hsm::state_t<SubState> {})).value()));
+        bh::typeid_(std::unique_ptr<SubState> {}),
+        bh::typeid_(*bh::find(statesMap, bh::typeid_(hsm::state_t<SubState> {})).value()));
 }
 
 TEST_F(MakeStatesMapTests, should_return_same_instance)
@@ -101,6 +101,6 @@ TEST_F(MakeStatesMapTests, should_return_same_instance)
     auto statesMap = hsm::make_states_map(hsm::state_t<MainState> {});
 
     auto s1 = bh::find(statesMap, bh::typeid_(hsm::state_t<S1> {})).value();
-    s1->data = std::string("42");
-    ASSERT_EQ("42", bh::find(statesMap, bh::typeid_(hsm::state_t<S1> {})).value()->data);
+    (*s1)->data = std::string("42");
+    ASSERT_EQ("42", (*bh::find(statesMap, bh::typeid_(hsm::state_t<S1> {})).value())->data);
 }


### PR DESCRIPTION
Added the feature to construct state during transition execution:
```c++
// Construct S2 with a state factory lambda
hsm::state<S1> {} + hsm::event<e1> {} / hsm::create(stateFactory) = hsm::state<S2> {}
// Reuse the constructed S2 otherwise you need construct it again
hsm::state<S1> {} + hsm::event<e2> {} / hsm::reuse(log) = hsm::state<S2> {}
```
The integratio test `test/integration/custom_targets.cpp` shows an example.
@BenjaminW3 it would be nice if you could review the usage of the feature if it fits your requirements