### PR TITLE
bug: Event deferring fails when parallel region with different start state is present

### DIFF
--- a/test/integration/defer_events.cpp
+++ b/test/integration/defer_events.cpp
@@ -11,24 +11,31 @@ namespace {
 // Events
 struct e1 {
 };
-struct e2 {
+struct defered1 {
 };
-struct e3 {
-    e3(int i)
+struct defered2 {
+    defered2(int i)
         : i(i)
     {
     }
     int i;
+};
+struct e4 {
 };
 
 // States
 struct S1 {
     static constexpr auto defer_events()
     {
-        return hsm::events<e2, e3>;
+        return hsm::events<defered1, defered2>;
     }
 };
 struct S2 {
+};
+
+struct PS1 {
+};
+struct PS2 {
 };
 
 using namespace ::testing;
@@ -39,10 +46,10 @@ struct MainState {
     {
         // clang-format off
         return hsm::transition_table(
-            * hsm::state<S1> + hsm::event<e1> = hsm::state<S2>
-            , hsm::state<S1> + hsm::event<e3> = hsm::state<S2>
-            , hsm::state<S2> + hsm::event<e2> = hsm::state<S1>
-              
+            * hsm::state<S1>  + hsm::event<e1>       = hsm::state<S2>
+            , hsm::state<S1>  + hsm::event<defered2> = hsm::state<S2>
+            , hsm::state<S2>  + hsm::event<defered1> = hsm::state<S1>
+            ,*hsm::state<PS1> + hsm::event<e4>       = hsm::state<PS2>              
         );
         // clang-format on
     }
@@ -58,7 +65,7 @@ class DeferEventsTests : public Test {
 TEST_F(DeferEventsTests, should_defer_event)
 {
     ASSERT_TRUE(sm.is(hsm::state<S1>));
-    sm.process_event(e2 {});
+    sm.process_event(defered1 {});
     ASSERT_TRUE(sm.is(hsm::state<S1>));
     sm.process_event(e1 {});
     ASSERT_TRUE(sm.is(hsm::state<S1>));
@@ -66,5 +73,5 @@ TEST_F(DeferEventsTests, should_defer_event)
 
 TEST_F(DeferEventsTests, should_defer_event_with_parameters)
 {
-    sm.process_event(e3 { 1 });
+    sm.process_event(defered2 { 1 });
 }


### PR DESCRIPTION
**Problem:**
The defer event test fails when a parallel region with a different start state is present.