### PR TITLE
[Reproducer] internal transition table without external transition table

### DIFF
--- a/src/include/hsm/details/flatten_internal_transition_table.h
+++ b/src/include/hsm/details/flatten_internal_transition_table.h
@@ -77,6 +77,21 @@ constexpr auto extend_internal_transition(Transition internalTransition, States 
     });
 }
 
+template <class Transition, class State>
+constexpr auto extend_internal_transition2(Transition internalTransition, State state)
+{
+        return bh::make_basic_tuple(details::internal_extended_transition(
+            // TODO: here the parentState of state should be used    
+            internalTransition.parent(),
+            details::transition(
+                state,
+                internalTransition.event(),
+                internalTransition.guard(),
+                internalTransition.action(),
+                state)));
+}
+
+
 /**
  * Returns the internal transitions for each for each state
  * [[transition1, transition2], [transition3, transition4], []]
@@ -95,7 +110,11 @@ constexpr auto get_internal_transitions = [](auto states) {
                           if constexpr (has_transition_table(parentState)) {
                               return extend_internal_transition(
                                   transition, collect_child_states(parentState));
-                          } else {
+                          } 
+                          else if constexpr (has_internal_transition_table(parentState)){
+                              return extend_internal_transition2(transition, parentState);
+                          }
+                          else {
                               return bh::make_basic_tuple();
                           }
                       });

--- a/src/include/hsm/details/sm.h
+++ b/src/include/hsm/details/sm.h
@@ -279,9 +279,10 @@ template <class RootState, class... OptionalParameters> class sm {
         }
     }
 
-    void fill_dispatch_table(OptionalParameters&... optionalParameters)
+    constexpr void fill_dispatch_table(OptionalParameters&... optionalParameters)
     {
         auto optionalDependency = bh::make_basic_tuple(std::ref(optionalParameters)...);
+        fill_dispatch_table_with_submachine_exits(rootState(), m_statesMap, optionalDependency);
         fill_dispatch_table_with_internal_transitions(rootState(), m_statesMap, optionalDependency);
         fill_dispatch_table_with_external_transitions(rootState(), m_statesMap, optionalDependency);
         fill_dispatch_table_with_deferred_events(rootState(), optionalDependency);


### PR DESCRIPTION
**Problem:**
A internal transition table is not recognized when the particular state has no external transition table.

**Workaround:**
Add an external transition table with a dummy transition (Dummy + dummy = Dummy)