### PR TITLE
[Reproducer] Fix/erikzenker/reproduce two anon events

### DIFF
--- a/include/hsm/details/dispatch_table.h
+++ b/include/hsm/details/dispatch_table.h
@@ -130,6 +130,7 @@ template <class Event> struct NextState {
     bool history{};
     bool defer{};
     bool valid = false;
+    bool internal = false;
     std::unique_ptr<IDispatchTableEntry<Event>> transition;
 };
 }

--- a/include/hsm/details/fill_dispatch_table.h
+++ b/include/hsm/details/fill_dispatch_table.h
@@ -72,11 +72,11 @@ constexpr auto addDispatchTableEntry(
                     auto fromIdx, auto toIdx, auto history, auto mappedSource, auto mappedTarget)
                     -> void {
                     bh::apply(
-                        [=](auto& dispatchTable, auto&& transition2) -> void {
+                        [=](auto& dispatchTable, auto&& transition2, bool internal) -> void {
                             const auto defer = false;
                             const auto valid = true;
                             dispatchTable[fromIdx].push_front(
-                                { toIdx, history, defer, valid, std::move(transition2) });
+                                { toIdx, history, defer, valid, internal, std::move(transition2) });
                         },
                         dispatchTables[eventTypeid],
                         make_transition(
@@ -85,7 +85,8 @@ constexpr auto addDispatchTableEntry(
                             eventTypeid,
                             mappedSource,
                             mappedTarget,
-                            optionalDependency));
+                            optionalDependency),
+                        transition.internal());
                 },
                 getCombinedStateIdx(combinedStateIds, resolveSrcParent(transition), source),
                 getCombinedStateIdx(combinedStateIds, resolveDstParent(transition), target),
@@ -130,13 +131,17 @@ constexpr auto addDispatchTableEntryOfSubMachineExits(
                             auto mappedParent,
                             auto mappedTarget) {
                             bh::apply(
-                                [=](auto& dispatchTable, auto&& transition2) {
+                                [=](auto& dispatchTable, auto&& transition2, bool internal) {
                                     const auto defer = false;
                                     const auto valid = true;
                                     // TODO: Since dispatch table is static, transitions might be
                                     // added twice
-                                    dispatchTable[fromIdx].push_front(
-                                        { toIdx, history, defer, valid, std::move(transition2) });
+                                    dispatchTable[fromIdx].push_front({ toIdx,
+                                                                        history,
+                                                                        defer,
+                                                                        valid,
+                                                                        internal,
+                                                                        std::move(transition2) });
                                 },
                                 dispatchTables[eventTypeid],
                                 make_transition(
@@ -145,7 +150,8 @@ constexpr auto addDispatchTableEntryOfSubMachineExits(
                                     eventTypeid,
                                     mappedParent,
                                     mappedTarget,
-                                    optionalDependency));
+                                    optionalDependency),
+                                transition.internal());
                         },
                         getCombinedStateIdx(combinedStateTypeids, parentState, state),
                         getCombinedStateIdx(

--- a/include/hsm/details/sm.h
+++ b/include/hsm/details/sm.h
@@ -206,6 +206,10 @@ template <class RootState, class... OptionalParameters> class sm {
     template <class DispatchTableEntry>
     void update_current_state(Region region, const DispatchTableEntry& dispatchTableEntry)
     {
+        if (dispatchTableEntry.internal) {
+            return;
+        }
+
         if constexpr (has_history(rootState)) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
             m_history[currentParentState()][region] = m_currentCombinedState[region];

--- a/include/hsm/details/sm.h
+++ b/include/hsm/details/sm.h
@@ -183,15 +183,14 @@ template <class RootState, class... OptionalParameters> class sm {
                         return;
                     }
 
-                    int i = 0;
                     for (auto& result : results) {
-                        std::cout << i++ << std::endl;
                         if (!result.transition->executeGuard(event)) {
                             continue;
                         }
 
                         update_current_state(region, result);
                         result.transition->executeAction(event);
+                        break;
                     }
                 }
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,7 @@ add_executable(
     integration/amalgamation_header.cpp
     integration/custom_targets.cpp
     integration/chain_actions.cpp
+    integration/reproducer.cpp
 )
 target_compile_features(hsmIntegrationTests PRIVATE cxx_std_17)
 target_link_libraries(hsmIntegrationTests PRIVATE hsm::hsm GTest::gtest_main)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,7 +77,7 @@ add_executable(
     integration/amalgamation_header.cpp
     integration/custom_targets.cpp
     integration/chain_actions.cpp
-    integration/reproducer.cpp
+    integration/reproducer/should_execute_anonymous_transition_once.cpp
 )
 target_compile_features(hsmIntegrationTests PRIVATE cxx_std_17)
 target_link_libraries(hsmIntegrationTests PRIVATE hsm::hsm GTest::gtest_main)

--- a/test/integration/internal_transition.cpp
+++ b/test/integration/internal_transition.cpp
@@ -56,6 +56,10 @@ struct e6 {
 struct e7 {
     std::string name = "e7";
 };
+struct e8 {
+};
+struct e9 {
+};
 
 // Guards
 const auto fail = [](auto /*event*/, auto /*source*/, auto /*target*/) { return false; };
@@ -81,7 +85,8 @@ struct SubState {
     {
         // clang-format off
         return hsm::transition_table(
-            + (hsm::event<e1>)
+            + (hsm::event<e1>),
+            + (hsm::event<e8>)
         );
         // clang-format on
     }
@@ -107,7 +112,9 @@ struct MainState {
             + (hsm::event<e1> ),
             + (hsm::event<e2> / action),
             + (hsm::event<e5> [fail] / hsm::log),
-            + (hsm::event<e4> [fail] / action)
+            + (hsm::event<e4> [fail] / action),
+            + (hsm::event<e8>),
+            + (hsm::event<e9>)
         );
         // clang-format on
     }
@@ -175,6 +182,26 @@ TEST_F(
     ASSERT_TRUE(sm.is(hsm::state<SubState>, hsm::state<S1>));
     sm.process_event(e5 {});
     ASSERT_TRUE(sm.is(hsm::state<SubState>, hsm::state<S3>));
+}
+
+TEST_F(
+    InternalTransitionTests,
+    should_not_overwrite_substate_internal_transition_by_parent_internal_transition)
+{
+    sm.process_event(e3 {});
+    sm.process_event(e1 {});
+    ASSERT_TRUE(sm.is(hsm::state<SubState>, hsm::state<S2>));
+    sm.process_event(e8 {});
+    ASSERT_TRUE(sm.is(hsm::state<SubState>, hsm::state<S2>));
+}
+
+TEST_F(InternalTransitionTests, should_not_transit_when_internal_transition_on_parent_state)
+{
+    sm.process_event(e3 {});
+    sm.process_event(e1 {});
+    ASSERT_TRUE(sm.is(hsm::state<SubState>, hsm::state<S2>));
+    sm.process_event(e9 {});
+    ASSERT_TRUE(sm.is(hsm::state<SubState>, hsm::state<S2>));
 }
 
 TEST_F(InternalTransitionTests, should_not_transit_to_initial_state)

--- a/test/integration/reproducer.cpp
+++ b/test/integration/reproducer.cpp
@@ -1,0 +1,114 @@
+#include "hsm/hsm.h"
+
+#include <boost/hana.hpp>
+#include <boost/hana/experimental/printable.hpp>
+#include <gtest/gtest.h>
+
+#include <future>
+#include <memory>
+
+namespace {
+
+using namespace ::testing;
+using namespace boost::hana;
+
+// States
+struct S1 {
+};
+struct S2 {
+};
+struct S3 {
+};
+struct S4 {
+};
+struct Exit {
+};
+
+// Events
+struct e1 {
+};
+struct e2 {
+};
+struct e3 {
+};
+struct e4 {
+};
+struct e5 {
+};
+struct e6 {
+};
+
+constexpr auto increaseCallCount
+    = [](const auto&, const auto&, const auto&, auto& dep) { dep.callCount++; };
+
+struct SubState1 {
+    static constexpr auto make_transition_table()
+    {
+        // clang-format off
+        return hsm::transition_table(
+            * hsm::state<S1>                  / hsm::log = hsm::state<S2>
+        );
+        // clang-format on
+    }
+};
+
+struct SubState2 {
+    static constexpr auto make_transition_table()
+    {
+        // clang-format off
+        return hsm::transition_table(
+            * hsm::state<S1>                  / hsm::chain(hsm::log, increaseCallCount) = hsm::state<S2>
+            , hsm::state<S2> + hsm::event<e4> / hsm::log = hsm::state<S3>
+        );
+        // clang-format on
+    }
+};
+
+struct MainState {
+    static constexpr auto make_transition_table()
+    {
+        // clang-format off
+        return hsm::transition_table(
+            //              Source     , Event                    , Target
+            * hsm::state<S1>            + hsm::event<e1> / hsm::log = hsm::state<SubState1>
+            , hsm::state<S1>            + hsm::event<e2> / hsm::log = hsm::state<SubState2>
+            , hsm::state<SubState1>     + hsm::event<e3> / hsm::log = hsm::state<SubState2>
+        );
+        // clang-format on
+    }
+
+    static constexpr auto on_unexpected_event()
+    {
+        return [](auto event) {
+            throw std::runtime_error(
+                std::string("unexpected event ") + experimental::print(typeid_(event)));
+        };
+    }
+};
+
+}
+
+struct Dependency {
+    std::size_t callCount = 0;
+};
+
+class ReproducerTests : public Test {
+  protected:
+    ReproducerTests()
+        : sm(dep)
+    {
+    }
+
+    Dependency dep;
+    hsm::sm<MainState, Dependency> sm;
+};
+
+TEST_F(ReproducerTests, shouldOnlyExecuteOneAnonymousTransition)
+{
+    ASSERT_TRUE(sm.is(hsm::state<MainState>, hsm::state<S1>));
+    sm.process_event(e2 {});
+    ASSERT_TRUE(sm.is(hsm::state<SubState2>, hsm::state<S2>));
+    sm.process_event(e4 {});
+    ASSERT_TRUE(sm.is(hsm::state<SubState2>, hsm::state<S3>));
+    ASSERT_EQ(1, dep.callCount);
+}

--- a/test/integration/reproducer/should_execute_anonymous_transition_once.cpp
+++ b/test/integration/reproducer/should_execute_anonymous_transition_once.cpp
@@ -103,7 +103,7 @@ class ReproducerTests : public Test {
     hsm::sm<MainState, Dependency> sm;
 };
 
-TEST_F(ReproducerTests, shouldOnlyExecuteOneAnonymousTransition)
+TEST_F(ReproducerTests, shouldExecuteAnonymousTransitionOnce)
 {
     ASSERT_TRUE(sm.is(hsm::state<MainState>, hsm::state<S1>));
     sm.process_event(e2 {});


### PR DESCRIPTION
This PR reproduces two issues

1. Anonymous transition execution is not stopped after the first successful transition for one anon event
2. Parent internal transition overwrite substate internal transitions