### PR TITLE
c++20 Windows issue reproducers and possible fixes

### DIFF
--- a/cmake/test-flags.cmake
+++ b/cmake/test-flags.cmake
@@ -3,6 +3,12 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror -Wall -Wextra -Wpedantic -g3 -O0")
 endif()
 
+
+if(MSVC_VERSION VERSION_GREATER_EQUAL 1920)
+	# Make sure __cplusplus is set correctly depending on std
+	string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus")
+endif()
+
 if("${HSM_CLANG_COVERAGE}")
   set(CMAKE_CXX_FLAGS "-fprofile-instr-generate -fcoverage-mapping")
 endif()

--- a/include/hsm/details/fill_dispatch_table.h
+++ b/include/hsm/details/fill_dispatch_table.h
@@ -125,7 +125,7 @@ constexpr auto addDispatchTableEntryOfSubMachineExits(
         return;
     }
 
-    constexpr auto parentState = transition.source();
+    const auto parentState = transition.source();
     if constexpr (has_transition_table(parentState)) {
         bh::for_each(collect_child_state_typeids(parentState), [=, &dispatchTables](auto state) {
             bh::apply(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,12 +47,12 @@ add_executable(
     unit/unexpected_event_handler_tables_tests.cpp
     unit/transition_tests.cpp
 )
-target_compile_features(hsmUnitTests PRIVATE cxx_std_17)
+target_compile_features(hsmUnitTests PRIVATE cxx_std_20)
 target_link_libraries(hsmUnitTests PRIVATE hsm::hsm GTest::gtest_main)
 gtest_discover_tests(hsmUnitTests TEST_PREFIX unit.)
 
 add_executable(hsmPerformanceTests performance/main.cpp)
-target_compile_features(hsmPerformanceTests PRIVATE cxx_std_17)
+target_compile_features(hsmPerformanceTests PRIVATE cxx_std_20)
 target_link_libraries(hsmPerformanceTests PRIVATE hsm::hsm GTest::gtest_main)
 gtest_discover_tests(hsmPerformanceTests TEST_PREFIX performance.)
 
@@ -63,6 +63,7 @@ add_executable(
     integration/direct_transition.cpp
     integration/entry_exit_actions.cpp
     integration/entry_exit_pseudo_states.cpp
+    integration/exit_pseudo_states_with_history.cpp
     integration/anonymous_transition.cpp
     integration/guards_actions.cpp
     integration/orthogonal_regions.cpp
@@ -92,6 +93,6 @@ if (UNIX)
     )
 endif()
 
-target_compile_features(hsmIntegrationTests PRIVATE cxx_std_17)
+target_compile_features(hsmIntegrationTests PRIVATE cxx_std_20)
 target_link_libraries(hsmIntegrationTests PRIVATE hsm::hsm GTest::gtest_main)
 gtest_discover_tests(hsmIntegrationTests TEST_PREFIX integration.)

--- a/test/integration/dependency_injection.cpp
+++ b/test/integration/dependency_injection.cpp
@@ -52,6 +52,11 @@ struct MainState {
 class DependencyInjectionTests : public Test {
   protected:
     struct Dependency {
+        explicit Dependency(int callCount)
+            : callCount(callCount)
+        {
+        }
+
         // Dependency is not copied, assigned, or moved
         Dependency(const Dependency&) = delete;
         Dependency(Dependency&&) = delete;

--- a/test/integration/exit_pseudo_states_with_history.cpp
+++ b/test/integration/exit_pseudo_states_with_history.cpp
@@ -1,0 +1,76 @@
+#include "hsm/hsm.h"
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using namespace boost::hana;
+
+namespace {
+
+// States
+// -- sub
+struct S1 {
+};
+struct S2 {
+};
+struct SExit1 {
+};
+struct SExit2 {
+};
+// -- main
+struct S3 {
+};
+struct S4 {
+};
+struct S5 {
+};
+
+// Events
+struct e1 {
+};
+struct e2 {
+};
+struct e3 {
+};
+
+struct SubState {
+    static constexpr auto make_transition_table()
+    {
+        using namespace hsm;
+
+        // clang-format off
+        return transition_table(
+            * state<S1>                                                                           = state<SExit1>,
+              state<S2>                  + event<e3>                                              = state<SExit2>
+            );
+        // clang-format on
+    }
+};
+
+struct MainState {
+    static constexpr auto make_transition_table()
+    {
+        using namespace hsm;
+
+        // clang-format off
+        return transition_table(
+            * state<S3>                                  + event<e1>                             = state<S4>,
+              state<S4>                                  + event<e2>                             = state<SubState>,
+              state<SubState>                            + event<e2>                             = history<SubState>,
+              state<S5>                                                                          = state<S4>,
+              hsm::exit<SubState, SExit1>                                                        = state<S5>,
+              hsm::exit<SubState, SExit2>                                                        = state<S4>
+            );
+        // clang-format on
+    }
+};
+
+}
+class ExitPseudoStatesWithHistoryTests : public Test {
+  protected:
+     hsm::sm<MainState> sm;
+};
+
+TEST_F(ExitPseudoStatesWithHistoryTests, should_compile)
+{
+}


### PR DESCRIPTION
-C2065, constexpr parentState not visible from lamba, make it const
-C2440, cannot convert from initializer list, add ctor

Only occurs with c++20, so enable this as well in the according
CMakeLists